### PR TITLE
Follow up Bug 1297571 - Updates needed to links on https://www.mozilla.org/en-US/foundation/trademarks/policy/

### DIFF
--- a/bedrock/foundation/templates/foundation/trademarks/index.html
+++ b/bedrock/foundation/templates/foundation/trademarks/index.html
@@ -18,7 +18,7 @@
   <ul>
     <li><b><a href="{{ url('foundation.trademarks.policy') }}">{{ _('Mozilla Trademark and Logo Usage Policy') }}</a></b></li>
     <li>
-      {% trans guide="http://www-archive.mozilla.org/foundation/identity-guidelines/" %}
+      {% trans guide=url('styleguide.home') %}
         <a href={{ guide }}>Visual Identity Guidelines</a> - to be followed when using our logos under the policy
       {% endtrans %}
     </li>


### PR DESCRIPTION
Updating one more legacy link on the Trademark Policy page.